### PR TITLE
[nrf toup] Test: Build: Don't put host file paths in firmware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,14 @@
 #
 #-------------------------------------------------------------------------------
 
+# Replace the path of this directory (CMAKE_CURRENT_SOURCE_DIR) with
+# the literal "TFM_TEST_REPO_PATH" in C preprocessor macro expansions
+# to prevent host file path information from leaking into __FILE__
+# macros and breaking reproducible builds.
+add_compile_options(
+  -fmacro-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=TFM_TEST_REPO_PATH
+  )
+
 add_subdirectory(log)
 
 if(NS)


### PR DESCRIPTION
Replace the path of tf-m-tests repo with the literal
"TFM_TEST_REPO_PATH" in C preprocessor macro expansions to prevent
host file path information from leaking into __FILE__ macros and
breaking reproducible builds.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>