### PR TITLE
build: suites: exclude attestation if not required

### DIFF
--- a/test/secure_fw/suites/CMakeLists.txt
+++ b/test/secure_fw/suites/CMakeLists.txt
@@ -67,13 +67,15 @@ endif()
 
 # Add test suites.
 # Secure test suite library targets shall already be added in secure_tests.cmake
-add_subdirectory(attestation)
+if(TEST_S_ATTESTATION)
+  add_subdirectory(attestation)
+  add_subdirectory(qcbor)
+  add_subdirectory(t_cose)
+endif()
 add_subdirectory(crypto)
 add_subdirectory(extra)
 add_subdirectory(its)
-add_subdirectory(qcbor)
 add_subdirectory(ps)
-add_subdirectory(t_cose)
 add_subdirectory(platform)
 add_subdirectory(fwu)
 add_subdirectory(multi_core/non_secure)


### PR DESCRIPTION
Restricts including the `attestation`, `qcbor`, and `t_cose` folders to situations where initial attestation services are actually required (`TEST_S_ATTESTATION` set). This check is required to avoid downloading QCBOR at compile time, which is pulled in as a dependency of t_cose.

This patch should be reverted once an acceptable upstream solution can be found.

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>