### PR TITLE
attest: fix check for ATTEST_TOKEN_PROFILE_ARM_CCA

### DIFF
--- a/tests_reg/test/secure_fw/suites/attestation/attest_token_decode.h
+++ b/tests_reg/test/secure_fw/suites/attestation/attest_token_decode.h
@@ -94,7 +94,7 @@ extern "C" {
  * Original defines are here:
  *     <TF-M>/interface/include/tfm_attest_iat_defs.h
  */
-#ifdef ATTEST_TOKEN_PROFILE_ARM_CCA
+#if ATTEST_TOKEN_PROFILE_ARM_CCA
 #define IAT_CLIENT_ID                      (IAT_ARM_RANGE_BASE + 1)
 #define IAT_BOOT_SEED                      (IAT_ARM_RANGE_BASE + 4)
 #define IAT_CERTIFICATION_REFERENCE        (IAT_ARM_RANGE_BASE + 5)


### PR DESCRIPTION
Cherry pick of https://review.trustedfirmware.org/c/TF-M/tf-m-tests/+/41857 to fix compilation of tests.