### PR TITLE
Add picolibc support

### DIFF
--- a/app_broker/syscalls_stub.c
+++ b/app_broker/syscalls_stub.c
@@ -14,6 +14,14 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __PICOLIBC__
+__attribute__((weak))
+void _exit(int status)
+{
+    (void) status;
+    for(;;);
+}
+#else
 __attribute__((weak))
 void _close(void)
 {
@@ -53,3 +61,4 @@ __attribute__((weak))
 void _write(void)
 {
 }
+#endif /* !__PICOLIBC__ */

--- a/tests_reg/test/framework/test_framework.c
+++ b/tests_reg/test/framework/test_framework.c
@@ -7,6 +7,8 @@
 
 #include "test_framework.h"
 
+/* Ensure assert is enabled */
+#undef NDEBUG
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
@@ -50,6 +52,7 @@ const char *test_err_to_str(enum test_suite_err_t err)
      *           covered in the switch.
      */
     }
+    assert(0);
 }
 
 enum test_suite_err_t run_test(const char *suite_type, struct test_suite_t test_suites[])

--- a/tests_reg/test/secure_fw/suites/crypto/crypto_tests_common.c
+++ b/tests_reg/test/secure_fw/suites/crypto/crypto_tests_common.c
@@ -5,6 +5,8 @@
  *
  */
 
+/* Ensure assert is enabled */
+#undef NDEBUG
 #include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>


### PR DESCRIPTION
This series allows these tests to be built using picolibc. 

The first patch adds a stub for `_exit` so that code can use assert(0) when compiled against picolibc.

The other two patches avoid compiler warnings (which become errors when built under twister).