### PR TITLE
[zep noup] app_broker: Provide stubs for picolibc

### DIFF
--- a/app_broker/syscalls_stub.c
+++ b/app_broker/syscalls_stub.c
@@ -14,6 +14,14 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __PICOLIBC__
+__attribute__((weak))
+void _exit(int status)
+{
+    (void) status;
+    for(;;);
+}
+#else
 __attribute__((weak))
 void _close(void)
 {
@@ -53,3 +61,4 @@ __attribute__((weak))
 void _write(void)
 {
 }
+#endif /* !__PICOLIBC__ */


### PR DESCRIPTION
When assert is used, picolibc will eventually call _exit. Provide a stub for that which spins to cause failing test cases to timeout.

As upstream plans to bring all C library functionality into the library, this should not be needed in the long term.