### PR TITLE
[zep noup] remove usage of psa_open_key/psa_close_key

### DIFF
--- a/tests_reg/test/secure_fw/suites/crypto/crypto_tests_common.c
+++ b/tests_reg/test/secure_fw/suites/crypto/crypto_tests_common.c
@@ -2337,17 +2337,11 @@ void psa_persistent_key_test(psa_key_id_t key_id, struct test_result_t *ret)
         return;
     }
 
-    /* Close the persistent key through the key ID */
-    status = psa_close_key(key_id_local);
+    /* Close the persistent key through the key ID.
+     * The key will be automatically reloaded on the next usage. */
+    status = psa_purge_key(key_id_local);
     if (status != PSA_SUCCESS) {
-        TEST_FAIL("Failed to close a persistent key");
-        return;
-    }
-
-    /* Open the previsously-created persistent key */
-    status = psa_open_key(key_id, &key_id_local);
-    if (status != PSA_SUCCESS) {
-        TEST_FAIL("Failed to open a persistent key");
+        TEST_FAIL("Failed to purge a persistent key");
         return;
     }
 

--- a/tests_reg/test/secure_fw/suites/crypto/secure/crypto_sec_interface_testsuite.c
+++ b/tests_reg/test/secure_fw/suites/crypto/secure/crypto_sec_interface_testsuite.c
@@ -457,7 +457,7 @@ static void tfm_crypto_test_1034(struct test_result_t *ret)
 static void tfm_crypto_test_1035(struct test_result_t *ret)
 {
     psa_status_t status;
-    psa_key_handle_t key_handle;
+    psa_key_id_t key_handle;
     const uint8_t data[] = "THIS IS MY KEY1";
     psa_key_attributes_t key_attributes = psa_key_attributes_init();
 


### PR DESCRIPTION
Those functions have been removed from PSA API since TF-PSA-Crypto 1.1. Since we're now building this test code inside the Zephyr app and since we transitioned to Mbed TLS 4.1/TF-PSA-Crypto 1.1 there, we need to stop using these functions.

psa_close_key -> psa_purge_key
psa_open_key -> not replacement, the key will be automatically reloaded
                on the next usage